### PR TITLE
Prevent erasing one too many blocks when flashing.

### DIFF
--- a/fw/pano_ldr/tftp_ldr.c
+++ b/fw/pano_ldr/tftp_ldr.c
@@ -127,7 +127,7 @@ static int tftp_write(void *handle, struct pbuf *pBuf)
          case TFTP_TYPE_FLASH: {
             const FlashInfo_t *pInfo = spi_get_flashinfo();
             uint32_t EraseSize = pInfo->EraseSize;
-            uint32_t LastAdr = Adr + BufLen;
+            uint32_t LastAdr = Adr + BufLen - 1;
             uint32_t EraseAdr;
             uint32_t EraseEnd = LastAdr - (LastAdr % EraseSize);
 


### PR DESCRIPTION
When the file being flashed was an exact multiple of erase blocks, it would erase one too many blocks.